### PR TITLE
Updated NOTICE & cabal files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.2.4", "9.4.2", "9.6.1"]
-        cabal: ["3.8.1.0"]
+        ghc: ["8.10", "9.2", "9.4", "9.6", "9.8"]
+        cabal: ["3.10.2.0"]
         os: [windows-latest, ubuntu-latest]
 
     steps:

--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -30,11 +30,11 @@ jobs:
         EOF
 
     - name: Install Haskell
-      uses: haskell/actions/setup@v1
+      uses: haskell-actions/setup@v2
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: 3.4.0.0
+        cabal-version: 3.10.2.0
 
     - name: Set up temp directory
       run: |
@@ -56,6 +56,9 @@ jobs:
 
     - name: Configure
       run: cabal configure --enable-documentation --enable-tests
+
+    - name: cabal build --dry-run
+      run: cabal build --dry-run all
 
     - name: build Haddock documentation 🔧
       run: |

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2019-2023 Input Output Global Ing (IOG), Intersect 2024
+Copyright 2019-2023 Input Output Global Ing (IOG), 2023-2024 Intersect
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2019 Input Output (Hong Kong) Ltd.
+Copyright 2019-2023 Input Output Global Ing (IOG), Intersect 2024
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Win32-network.cabal
+++ b/Win32-network.cabal
@@ -1,5 +1,4 @@
-cabal-version: 2.4
-
+cabal-version:          2.4
 name:                   Win32-network
 version:                0.1.1.1
 synopsis:               Win32 network API
@@ -7,7 +6,7 @@ license:                Apache-2.0
 license-files:          LICENSE NOTICE
 author:                 Duncan Coutts, Marcin Szamotulski
 maintainer:             duncan@well-typed.com, marcin.szamotulski@iohk.io
-copyright:              2019 Input Output (Hong Kong) Ltd.
+copyright:              2019-2023 Input Output Global Inc (IOG), Intersect 2024
 category:               System
 build-type:             Simple
 extra-source-files:     README.md

--- a/Win32-network.cabal
+++ b/Win32-network.cabal
@@ -1,4 +1,4 @@
-cabal-version:          2.4
+cabal-version:          3.0
 name:                   Win32-network
 version:                0.1.1.1
 synopsis:               Win32 network API
@@ -6,13 +6,13 @@ license:                Apache-2.0
 license-files:          LICENSE NOTICE
 author:                 Duncan Coutts, Marcin Szamotulski
 maintainer:             duncan@well-typed.com, marcin.szamotulski@iohk.io
-copyright:              2019-2023 Input Output Global Inc (IOG), Intersect 2024
+copyright:              2019-2023 Input Output Global Inc (IOG), 2023-2024 Intersect
 category:               System
 build-type:             Simple
 extra-source-files:     README.md
                         ChangeLog.md
                         include/Win32-network.h
-tested-with:            GHC==8.10.7, GHC==9.2.4, GHC==9.4.2
+tested-with:            GHC == {8.10, 9.2, 9.4, 9.6, 9.8}
 
 source-repository head
   type:                 git

--- a/test/Test/Async/Socket.hs
+++ b/test/Test/Async/Socket.hs
@@ -1,9 +1,13 @@
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE NumericUnderscores  #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
+
+#if MIN_VERSION_GLASGOW_HASKELL(9,8,0,0)
+{-# OPTIONS_GHC -Wno-x-partial #-}
+#endif
 
 module Test.Async.Socket (tests) where
 


### PR DESCRIPTION
* Updated NOTICE & cabal files
* Compile with `ghc-9.8`, use it in GHA.